### PR TITLE
DRAFT: verticalLabelDD for coordinate osurf

### DIFF
--- a/src/cmip_branded_variable_mapper/vertical_label.py
+++ b/src/cmip_branded_variable_mapper/vertical_label.py
@@ -30,6 +30,7 @@ VERTICAL_LABEL_DIMENSIONS_MAPPER = DimensionMapper(
         "olayer700m": "d700m",
         "olayer2000m": "d2000m",
         "op20bar": "op20bar",
+        "osurf": "ols",
         "p10": "10hPa",
         "p100": "100hPa",
         "p200": "200hPa",


### PR DESCRIPTION
## Description

One-line change to add a verticalLabelDD for new coordinate `osurf`.

Used label `ols` based on @taylor13's [suggestion here](https://github.com/CMIP-Data-Request/Harmonised-Public-Consultation/issues/112#issuecomment-3666371683). `oltop` was also suggested - if this is preferable it's a easy change.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`
